### PR TITLE
TOOLS-2359 javascriptlint breaks on 19.2 images because it is incompatible with python3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,12 @@ CPPFLAGS += -DNDEBUG -D_REENTRANT					\
 	-Ispidermonkey/src -Ispidermonkey/src/build			\
 	-I/usr/include							\
 
-PY_EXEC=$(shell which python2)
+# Try to get a Python 2. On macOS there isn't a "python2". On
+# SmartOS pkgsrc 2019Q2 minimal "python" is v3.
+PY_EXEC=$(shell which python2.7)
+ifndef PY_EXEC
+	PY_EXEC=$(shell which python2)
+endif
 ifndef PY_EXEC
 	PY_EXEC=python
 endif

--- a/Makefile
+++ b/Makefile
@@ -16,8 +16,11 @@ CPPFLAGS += -DNDEBUG -D_REENTRANT					\
 	-Ispidermonkey/src -Ispidermonkey/src/build			\
 	-I/usr/include							\
 
-
-PY_PYTHON=$(shell python -c "import sys; print(sys.executable)")
+PY_EXEC=$(shell which python2)
+ifndef PY_EXEC
+	PY_EXEC=python
+endif
+PY_PYTHON=$(shell $(PY_EXEC) -c "import sys; print(sys.executable)")
 PY_PREFIX=$(shell $(PY_PYTHON) -c "import sys; print(sys.real_prefix)" || $(PY_PYTHON) -c "import sys; print(sys.prefix)")
 PY_VERSION=$(shell $(PY_PYTHON) -c "import sys; print('.'.join(map(str, sys.version_info[:2])))")
 ifeq ($(BUILDOS),Darwin)


### PR DESCRIPTION
This attempts to only use Python 2 -- looking for `which python2` first
in case `which python` is actually a Python 3.